### PR TITLE
Add SpotDetail activity with Firebase integration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -24,6 +26,7 @@
             </intent-filter>
         </activity>
         <activity android:name="com.pnu.pnuguide.ui.course.SpotListActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.course.SpotDetailActivity" />
         <activity android:name="com.pnu.pnuguide.ui.SettingsActivity" />
     </application>
 

--- a/app/src/main/java/com/pnu/pnuguide/data/AuthRepository.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/AuthRepository.kt
@@ -1,0 +1,23 @@
+package com.pnu.pnuguide.data
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.android.gms.tasks.Task
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+object AuthRepository {
+    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
+    var uid: String? = null
+        private set
+
+    suspend fun signInAnonymously() {
+        val result = auth.signInAnonymously().await()
+        uid = result.user?.uid
+    }
+}
+
+private suspend fun <T> Task<T>.await(): T = suspendCancellableCoroutine { cont ->
+    addOnSuccessListener { cont.resume(it) }
+    addOnFailureListener { cont.resumeWithException(it) }
+}

--- a/app/src/main/java/com/pnu/pnuguide/data/StampRepository.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/StampRepository.kt
@@ -1,0 +1,29 @@
+package com.pnu.pnuguide.data
+
+import com.google.android.gms.tasks.Task
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
+import com.google.firebase.firestore.ktx.firestoreSettings
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+object StampRepository {
+    private val firestore = FirebaseFirestore.getInstance().apply {
+        firestoreSettings = firestoreSettings { isPersistenceEnabled = true }
+    }
+
+    suspend fun addSpotToStamps(uid: String, spotId: String) {
+        val doc = firestore.collection("stamps").document(uid)
+        doc.set(
+            mapOf("collectedSpots" to FieldValue.arrayUnion(spotId)),
+            SetOptions.merge()
+        ).await()
+    }
+}
+
+private suspend fun <T> Task<T>.await(): T = suspendCancellableCoroutine { cont ->
+    addOnSuccessListener { cont.resume(it) }
+    addOnFailureListener { cont.resumeWithException(it) }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/SpotDetailActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/SpotDetailActivity.kt
@@ -1,0 +1,45 @@
+package com.pnu.pnuguide.ui.course
+
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import android.widget.ImageView
+import android.widget.TextView
+import com.google.android.material.button.MaterialButton
+import com.pnu.pnuguide.R
+
+class SpotDetailActivity : AppCompatActivity() {
+
+    private val viewModel by viewModels<SpotDetailViewModel>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_spot_detail)
+
+        val title = intent.getStringExtra(EXTRA_TITLE) ?: ""
+        val desc = intent.getStringExtra(EXTRA_DESCRIPTION) ?: ""
+        val imageRes = intent.getIntExtra(EXTRA_IMAGE_RES, 0)
+        val videoId = intent.getStringExtra(EXTRA_VIDEO_ID) ?: ""
+        val spotId = intent.getStringExtra(EXTRA_SPOT_ID) ?: ""
+
+        findViewById<ImageView>(R.id.image_spot).setImageResource(imageRes)
+        findViewById<TextView>(R.id.text_title).text = title
+        findViewById<TextView>(R.id.text_description).text = desc
+
+        findViewById<MaterialButton>(R.id.button_watch_video).setOnClickListener {
+            viewModel.openYoutube(this, videoId)
+        }
+
+        findViewById<MaterialButton>(R.id.button_collect_stamp).setOnClickListener {
+            viewModel.addStamp(spotId)
+        }
+    }
+
+    companion object {
+        const val EXTRA_TITLE = "extra_title"
+        const val EXTRA_DESCRIPTION = "extra_description"
+        const val EXTRA_IMAGE_RES = "extra_image_res"
+        const val EXTRA_VIDEO_ID = "extra_video_id"
+        const val EXTRA_SPOT_ID = "extra_spot_id"
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/SpotDetailViewModel.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/SpotDetailViewModel.kt
@@ -1,0 +1,57 @@
+package com.pnu.pnuguide.ui.course
+
+import android.app.AlertDialog
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pnu.pnuguide.data.AuthRepository
+import com.pnu.pnuguide.data.StampRepository
+import kotlinx.coroutines.launch
+
+class SpotDetailViewModel(
+    private val authRepository: AuthRepository = AuthRepository,
+    private val stampRepository: StampRepository = StampRepository
+) : ViewModel() {
+
+    init {
+        viewModelScope.launch {
+            try {
+                authRepository.signInAnonymously()
+            } catch (_: Exception) {
+                // handle error in UI if needed
+            }
+        }
+    }
+
+    fun openYoutube(context: Context, videoId: String) {
+        viewModelScope.launch {
+            val appIntent = Intent(Intent.ACTION_VIEW, Uri.parse("vnd.youtube:$videoId"))
+            val webIntent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.youtube.com/watch?v=$videoId"))
+            try {
+                context.startActivity(appIntent)
+            } catch (e: Exception) {
+                try {
+                    context.startActivity(webIntent)
+                } catch (ex: Exception) {
+                    AlertDialog.Builder(context)
+                        .setMessage("Unable to open video")
+                        .setPositiveButton(android.R.string.ok, null)
+                        .show()
+                }
+            }
+        }
+    }
+
+    fun addStamp(spotId: String) {
+        viewModelScope.launch {
+            try {
+                val uid = authRepository.uid ?: return@launch
+                stampRepository.addSpotToStamps(uid, spotId)
+            } catch (_: Exception) {
+                // error handling left to UI
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_spot_detail.xml
+++ b/app/src/main/res/layout/activity_spot_detail.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <ImageView
+        android:id="@+id/image_spot"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:scaleType="centerCrop" />
+
+    <TextView
+        android:id="@+id/text_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:textSize="24sp"
+        android:paddingTop="16dp" />
+
+    <TextView
+        android:id="@+id/text_description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="14sp"
+        android:paddingTop="8dp" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_watch_video"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/watch_video"
+        android:layout_marginTop="24dp"
+        style="@style/Widget.Material3.Button" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_collect_stamp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/collect_stamp"
+        android:layout_marginTop="8dp"
+        style="@style/Widget.Material3.Button" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
     <string name="title_chat">Chat</string>
     <string name="menu_settings">Settings</string>
     <string name="menu_reset_nickname">Reset Nickname</string>
+    <string name="watch_video">Watch Video</string>
+    <string name="collect_stamp">Collect Stamp</string>
 </resources>


### PR DESCRIPTION
## Summary
- add layout and resources for SpotDetailActivity
- implement SpotDetailActivity and ViewModel
- include AuthRepository and StampRepository for Firebase auth and Firestore
- register new activity and Internet permission
- scaffold Firebase dependencies

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684647457b448322a331b667afd5f1b3