### PR TITLE
Add activity navigation and adjust bottom nav

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,12 @@
         </activity>
         <activity android:name="com.pnu.pnuguide.ui.LoginActivity" />
         <activity android:name=".MainActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.home.HomeActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.map.MapActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.profile.ProfileActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.course.CourseActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.stamp.StampActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.chat.ChatActivity" />
         <activity android:name="com.pnu.pnuguide.ui.course.SpotListActivity" />
         <activity android:name="com.pnu.pnuguide.ui.course.SpotDetailActivity" />
         <activity android:name="com.pnu.pnuguide.ui.SettingsActivity" />

--- a/app/src/main/java/com/pnu/pnuguide/MainActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/MainActivity.kt
@@ -4,12 +4,15 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import androidx.fragment.app.commit
-import com.pnu.pnuguide.ui.home.HomeFragment
-import com.pnu.pnuguide.ui.map.MapFragment
-import com.pnu.pnuguide.ui.profile.ProfileFragment
+import com.pnu.pnuguide.ui.home.HomeActivity
+import com.pnu.pnuguide.ui.map.MapActivity
+import com.pnu.pnuguide.ui.profile.ProfileActivity
+import com.pnu.pnuguide.ui.course.CourseActivity
+import com.pnu.pnuguide.ui.stamp.StampActivity
+import com.pnu.pnuguide.ui.chat.ChatActivity
 import android.content.Intent
 import com.pnu.pnuguide.ui.SettingsActivity
+import com.google.android.material.button.MaterialButton
 
 class MainActivity : AppCompatActivity() {
 
@@ -33,20 +36,24 @@ class MainActivity : AppCompatActivity() {
         val bottomNav = findViewById<BottomNavigationView>(R.id.bottom_nav)
         bottomNav.setOnItemSelectedListener { menuItem ->
             when (menuItem.itemId) {
-                R.id.nav_home -> switchFragment(HomeFragment())
-                R.id.nav_map -> switchFragment(MapFragment())
-                R.id.nav_profile -> switchFragment(ProfileFragment())
+                R.id.nav_home -> startActivity(Intent(this, HomeActivity::class.java))
+                R.id.nav_map -> startActivity(Intent(this, MapActivity::class.java))
+                R.id.nav_profile -> startActivity(Intent(this, ProfileActivity::class.java))
             }
             true
         }
         if (savedInstanceState == null) {
             bottomNav.selectedItemId = R.id.nav_home
         }
-    }
 
-            private fun switchFragment(fragment: androidx.fragment.app.Fragment) {
-        supportFragmentManager.commit {
-            replace(R.id.fragment_container, fragment)
+        findViewById<MaterialButton>(R.id.btn_course).setOnClickListener {
+            startActivity(Intent(this, CourseActivity::class.java))
+        }
+        findViewById<MaterialButton>(R.id.btn_stamp).setOnClickListener {
+            startActivity(Intent(this, StampActivity::class.java))
+        }
+        findViewById<MaterialButton>(R.id.btn_chat).setOnClickListener {
+            startActivity(Intent(this, ChatActivity::class.java))
         }
     }
 

--- a/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
@@ -1,0 +1,12 @@
+package com.pnu.pnuguide.ui.chat
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.pnu.pnuguide.R
+
+class ChatActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.fragment_chat)
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
@@ -1,0 +1,12 @@
+package com.pnu.pnuguide.ui.course
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.pnu.pnuguide.R
+
+class CourseActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.fragment_course)
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/HomeActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/HomeActivity.kt
@@ -1,0 +1,12 @@
+package com.pnu.pnuguide.ui.home
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.pnu.pnuguide.R
+
+class HomeActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.fragment_home)
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/MapActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/MapActivity.kt
@@ -1,0 +1,12 @@
+package com.pnu.pnuguide.ui.map
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.pnu.pnuguide.R
+
+class MapActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.fragment_map)
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/ProfileActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/ProfileActivity.kt
@@ -1,0 +1,12 @@
+package com.pnu.pnuguide.ui.profile
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.pnu.pnuguide.R
+
+class ProfileActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.fragment_profile)
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
@@ -1,0 +1,12 @@
+package com.pnu.pnuguide.ui.stamp
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.pnu.pnuguide.R
+
+class StampActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.fragment_stamp)
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -113,7 +113,7 @@
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_nav"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="72dp"
         android:background="@color/background_light"
         app:menu="@menu/menu_bottom_nav" />
 


### PR DESCRIPTION
## Summary
- open HomeActivity/MapActivity/ProfileActivity when bottom nav is tapped
- launch CourseActivity/StampActivity/ChatActivity from main screen buttons
- enlarge the BottomNavigationView height to avoid icon overlap
- register new activities in the manifest

## Testing
- `./gradlew test --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_684696c7a46883229710b3dd49c3d58b