### PR TITLE
Implement onboarding timer and signup screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
             </intent-filter>
         </activity>
         <activity android:name="com.pnu.pnuguide.ui.LoginActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.signup.SignUpActivity" />
         <activity android:name=".MainActivity" />
         <activity android:name="com.pnu.pnuguide.ui.home.HomeActivity" />
         <activity android:name="com.pnu.pnuguide.ui.map.MapActivity" />

--- a/app/src/main/java/com/pnu/pnuguide/ui/LoginActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/LoginActivity.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.button.MaterialButton
 import com.pnu.pnuguide.MainActivity
 import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.signup.SignUpActivity
 
 class LoginActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -15,6 +16,10 @@ class LoginActivity : AppCompatActivity() {
         findViewById<MaterialButton>(R.id.button_login).setOnClickListener {
             startActivity(Intent(this, MainActivity::class.java))
             finish()
+        }
+
+        findViewById<MaterialButton>(R.id.button_signup).setOnClickListener {
+            startActivity(Intent(this, SignUpActivity::class.java))
         }
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/OnboardingActivity.kt
@@ -2,18 +2,37 @@ package com.pnu.pnuguide.ui
 
 import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
 import com.pnu.pnuguide.R
 import com.google.android.material.button.MaterialButton
 
 class OnboardingActivity : AppCompatActivity() {
+    private val handler = Handler(Looper.getMainLooper())
+
+    private val navigateRunnable = Runnable {
+        startActivity(Intent(this, LoginActivity::class.java))
+        finish()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_onboarding)
 
         findViewById<MaterialButton>(R.id.button_get_started).setOnClickListener {
-            startActivity(Intent(this, LoginActivity::class.java))
-            finish()
+            handler.removeCallbacks(navigateRunnable)
+            navigateRunnable.run()
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        handler.postDelayed(navigateRunnable, 2000)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        handler.removeCallbacks(navigateRunnable)
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/signup/SignUpActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/signup/SignUpActivity.kt
@@ -1,0 +1,20 @@
+package com.pnu.pnuguide.ui.signup
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.button.MaterialButton
+import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.LoginActivity
+
+class SignUpActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_sign_up)
+
+        findViewById<MaterialButton>(R.id.button_sign_up).setOnClickListener {
+            startActivity(Intent(this, LoginActivity::class.java))
+            finish()
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp"
+    android:background="@color/background_light">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/sign_up"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:textColor="@color/text_primary"
+        android:gravity="center"
+        android:paddingTop="16dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="4dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="24dp">
+
+                <EditText
+                    android:id="@+id/edit_name"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:background="@color/divider"
+                    android:hint="@string/name"
+                    android:padding="12dp"
+                    android:textColor="@color/text_primary"
+                    android:textColorHint="@color/text_secondary"
+                    android:layout_marginBottom="12dp" />
+
+                <EditText
+                    android:id="@+id/edit_email"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:background="@color/divider"
+                    android:hint="@string/email"
+                    android:padding="12dp"
+                    android:textColor="@color/text_primary"
+                    android:textColorHint="@color/text_secondary"
+                    android:layout_marginBottom="12dp" />
+
+                <EditText
+                    android:id="@+id/edit_password"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:background="@color/divider"
+                    android:hint="@string/password"
+                    android:padding="12dp"
+                    android:textColor="@color/text_primary"
+                    android:textColorHint="@color/text_secondary"
+                    android:inputType="textPassword"
+                    android:layout_marginBottom="12dp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/button_sign_up"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:text="@string/sign_up"
+                    android:textStyle="bold"
+                    android:textColor="@android:color/white"
+                    app:backgroundTint="@color/primary"
+                    app:cornerRadius="8dp" />
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="log_in_or_sign_up">Log in or sign up</string>
     <string name="email">Email</string>
     <string name="password">Password</string>
+    <string name="name">Name</string>
     <string name="settings">Settings</string>
     <string name="pnu_guide">PNU Guide</string>
     <string name="pnu_guide_update">PNU Guide Update</string>


### PR DESCRIPTION
## Summary
- add automatic navigation from onboarding to login
- link login screen to new SignUpActivity
- implement SignUpActivity and layout
- register signup activity in the manifest
- include new `name` string for sign-up form

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6846b99baa3483229af4828093d94170