### PR TITLE
Add toolbar back navigation

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
@@ -2,11 +2,16 @@ package com.pnu.pnuguide.ui.chat
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
 
 class ChatActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.fragment_chat)
+
+        val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_chat)
+        setSupportActionBar(toolbar)
+        toolbar.setNavigationOnClickListener { finish() }
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
@@ -2,11 +2,16 @@ package com.pnu.pnuguide.ui.course
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
 
 class CourseActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.fragment_course)
+
+        val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_course)
+        setSupportActionBar(toolbar)
+        toolbar.setNavigationOnClickListener { finish() }
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
@@ -2,11 +2,16 @@ package com.pnu.pnuguide.ui.stamp
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
 
 class StampActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.fragment_stamp)
+
+        val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_stamp)
+        setSupportActionBar(toolbar)
+        toolbar.setNavigationOnClickListener { finish() }
     }
 }

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -1,9 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:padding="16dp">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_chat"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_light"
+        android:navigationIcon="@drawable/ic_arrow_back_black_24"
+        android:title="@string/title_chatbot"
+        android:titleTextColor="@color/text_primary"
+        app:titleCentered="true" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_chat"

--- a/app/src/main/res/layout/fragment_course.xml
+++ b/app/src/main/res/layout/fragment_course.xml
@@ -1,11 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_course"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_light"
+        android:navigationIcon="@drawable/ic_arrow_back_black_24"
+        android:title="@string/title_course"
+        android:titleTextColor="@color/text_primary"
+        app:titleCentered="true" />
 
     <TextView
         android:id="@+id/text_course"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Course Fragment" />
-</FrameLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_stamp.xml
+++ b/app/src/main/res/layout/fragment_stamp.xml
@@ -1,11 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_stamp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_light"
+        android:navigationIcon="@drawable/ic_arrow_back_black_24"
+        android:title="@string/title_stamp"
+        android:titleTextColor="@color/text_primary"
+        app:titleCentered="true" />
 
     <TextView
         android:id="@+id/text_stamp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Stamp Fragment" />
-</FrameLayout>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,7 @@
     <string name="settings">Settings</string>
     <string name="pnu_guide">PNU Guide</string>
     <string name="pnu_guide_update">PNU Guide Update</string>
+    <string name="title_course">Course</string>
+    <string name="title_stamp">Stamp</string>
+    <string name="title_chatbot">Chatbot</string>
 </resources>


### PR DESCRIPTION
## Summary
- add MaterialToolbar to course, stamp and chat screens
- implement back arrow navigation in their activities
- provide string resources for toolbar titles

## Testing
- `./gradlew assembleDebug` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6846c0a54ad88322bdaa56b3bd45816d