### PR TITLE
Add stamp collection fragment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,7 @@ android {
     buildFeatures {
         compose = true
         buildConfig = true
+        viewBinding = true
     }
 }
 
@@ -100,6 +101,9 @@ dependencies {
     implementation("androidx.navigation:navigation-ui-ktx:2.7.7")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.0")
     implementation("androidx.recyclerview:recyclerview:1.3.2")
+    implementation("androidx.camera:camera-camera2:1.3.2")
+    implementation("androidx.camera:camera-lifecycle:1.3.2")
+    implementation("androidx.camera:camera-view:1.3.2")
 
     // Firebase
     implementation(platform("com.google.firebase:firebase-bom:33.1.0"))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
-import com.pnu.pnuguide.ui.setupHeader1
+import com.pnu.pnuguide.ui.setupHeader2
 
 class StampActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -12,6 +12,6 @@ class StampActivity : AppCompatActivity() {
         setContentView(R.layout.fragment_stamp)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_stamp)
-        toolbar.setupHeader1(this, R.string.title_stamp)
+        toolbar.setupHeader2(this, R.string.title_stamp)
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampAdapter.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampAdapter.kt
@@ -1,0 +1,38 @@
+package com.pnu.pnuguide.ui.stamp
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.recyclerview.widget.RecyclerView
+import com.pnu.pnuguide.R
+
+class StampAdapter : RecyclerView.Adapter<StampAdapter.StampViewHolder>() {
+    private val items = MutableList(8) { false }
+
+    fun submitList(list: List<Boolean>) {
+        for (i in items.indices) {
+            items[i] = list.getOrElse(i) { false }
+        }
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StampViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_stamp_slot, parent, false)
+        return StampViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: StampViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    class StampViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val image: ImageView = itemView.findViewById(R.id.image_stamp)
+        fun bind(collected: Boolean) {
+            image.visibility = if (collected) View.VISIBLE else View.GONE
+        }
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampFragment.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampFragment.kt
@@ -1,44 +1,113 @@
 package com.pnu.pnuguide.ui.stamp
 
-import android.content.Intent
-import android.graphics.Bitmap
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Bundle
-import android.provider.MediaStore
-import androidx.appcompat.app.AppCompatActivity
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.pnu.pnuguide.R
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory
+import androidx.recyclerview.widget.GridLayoutManager
+
+import com.pnu.pnuguide.databinding.FragmentStampBinding
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Locale
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.core.content.ContextCompat.getMainExecutor
 
 class StampFragment : Fragment() {
 
-    private val viewModel by viewModels<StampViewModel>()
+    private var _binding: FragmentStampBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel by viewModels<StampViewModel> {
+        AndroidViewModelFactory.getInstance(requireActivity().application)
+    }
+
+    private lateinit var imageCapture: ImageCapture
+
+    private val requestPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            if (granted) startCamera() else Toast.makeText(requireContext(), "Permission denied", Toast.LENGTH_SHORT).show()
+        }
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.fragment_stamp, container, false)
+    ): View {
+        _binding = FragmentStampBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        // TODO: setup map and camera intent
-    }
+        binding.recyclerStamps.layoutManager = GridLayoutManager(requireContext(), 4)
+        val adapter = StampAdapter()
+        binding.recyclerStamps.adapter = adapter
 
-    private fun dispatchTakePicture() {
-        val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-        startActivityForResult(intent, 100)
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode == 100 && resultCode == AppCompatActivity.RESULT_OK) {
-            val bitmap = data?.extras?.get("data") as? Bitmap ?: return
-            viewModel.processImage(bitmap)
+        viewModel.stamps.observe(viewLifecycleOwner) {
+            adapter.submitList(it)
         }
+
+        viewModel.error.observe(viewLifecycleOwner) { failed ->
+            if (failed) {
+                Toast.makeText(requireContext(), getString(com.pnu.pnuguide.R.string.stamp_failed), Toast.LENGTH_SHORT).show()
+                viewModel.clearError()
+            }
+        }
+
+        binding.toolbarStamp.setNavigationOnClickListener { requireActivity().finish() }
+        binding.buttonCapture.setOnClickListener {
+            if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
+                startCamera()
+            } else {
+                requestPermission.launch(Manifest.permission.CAMERA)
+            }
+        }
+    }
+
+    private fun startCamera() {
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(requireContext())
+        cameraProviderFuture.addListener({
+            val cameraProvider = cameraProviderFuture.get()
+            imageCapture = ImageCapture.Builder().build()
+            try {
+                cameraProvider.unbindAll()
+                cameraProvider.bindToLifecycle(this, CameraSelector.DEFAULT_BACK_CAMERA, imageCapture)
+                capturePhoto()
+            } catch (e: Exception) {
+                Log.e("StampFragment", "Use case binding failed", e)
+            }
+        }, getMainExecutor(requireContext()))
+    }
+
+    private fun capturePhoto() {
+        val file = File(requireContext().cacheDir, SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(System.currentTimeMillis()) + ".jpg")
+        val output = ImageCapture.OutputFileOptions.Builder(file).build()
+        imageCapture.takePicture(output, getMainExecutor(requireContext()), object : ImageCapture.OnImageSavedCallback {
+            override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
+                viewModel.processImage(file)
+            }
+            override fun onError(exception: ImageCaptureException) {
+                Toast.makeText(requireContext(), getString(com.pnu.pnuguide.R.string.stamp_failed), Toast.LENGTH_SHORT).show()
+            }
+        })
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampViewModel.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampViewModel.kt
@@ -1,25 +1,55 @@
 package com.pnu.pnuguide.ui.stamp
 
+import android.app.Application
 import android.graphics.Bitmap
-import androidx.lifecycle.ViewModel
+import android.graphics.BitmapFactory
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.pnu.pnuguide.data.MLImageHelper
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.io.File
 
-class StampViewModel : ViewModel() {
+class StampViewModel(private val app: Application) : AndroidViewModel(app) {
 
-    private val _stamps = MutableStateFlow<List<String>>(emptyList())
-    val stamps: StateFlow<List<String>> = _stamps
+    private val prefs = app.getSharedPreferences("stamps", 0)
 
-    fun processImage(bitmap: Bitmap) {
-        viewModelScope.launch {
-            // TODO: run ML model
+    private val _stamps = MutableLiveData(loadStamps())
+    val stamps: LiveData<List<Boolean>> = _stamps
+
+    private fun loadStamps(): List<Boolean> =
+        List(8) { prefs.getBoolean("slot_$it", false) }
+
+    private fun saveStamp(index: Int) {
+        prefs.edit().putBoolean("slot_$index", true).apply()
+    }
+
+    fun processImage(file: File) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val bitmap = BitmapFactory.decodeFile(file.absolutePath)
             val match = MLImageHelper.matchSpot(bitmap)
             if (match != null) {
-                // TODO: update Firestore
+                markNextStamp()
+            } else {
+                _error.postValue(true)
             }
         }
     }
+
+    private fun markNextStamp() {
+        val current = _stamps.value?.toMutableList() ?: MutableList(8) { false }
+        val idx = current.indexOfFirst { !it }
+        if (idx != -1) {
+            current[idx] = true
+            saveStamp(idx)
+            _stamps.postValue(current)
+        }
+    }
+
+    private val _error = MutableLiveData(false)
+    val error: LiveData<Boolean> = _error
+
+    fun clearError() { _error.value = false }
 }

--- a/app/src/main/res/drawable/ic_stamp.xml
+++ b/app/src/main/res/drawable/ic_stamp.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FF000000"
+        android:pathData="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+</vector>

--- a/app/src/main/res/drawable/stamp_slot_background.xml
+++ b/app/src/main/res/drawable/stamp_slot_background.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@android:color/transparent"/>
+    <stroke android:width="1dp" android:color="@color/divider"/>
+</shape>

--- a/app/src/main/res/layout/fragment_stamp.xml
+++ b/app/src/main/res/layout/fragment_stamp.xml
@@ -1,23 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar_stamp"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:background="@color/background_light"
         android:navigationIcon="@drawable/ic_arrow_back_black_24"
         android:title="@string/title_stamp"
         android:titleTextColor="@color/text_primary"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:titleCentered="true" />
 
-    <TextView
-        android:id="@+id/text_stamp"
-        android:layout_width="wrap_content"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_stamps"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_stamp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/button_capture"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_capture"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="Stamp Fragment" />
-</LinearLayout>
+        android:text="@string/stamp_capture"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_stamp_slot.xml
+++ b/app/src/main/res/layout/item_stamp_slot.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:foreground="?selectableItemBackground"
+    android:background="@drawable/stamp_slot_background">
+
+    <ImageView
+        android:id="@+id/image_stamp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="centerInside"
+        android:src="@drawable/ic_stamp"
+        android:visibility="gone" />
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,6 @@
     <string name="title_stamp">Stamp</string>
     <string name="title_chatbot">Chatbot</string>
     <string name="hint_search_map">Search location</string>
+    <string name="stamp_capture">인증하기</string>
+    <string name="stamp_failed">인증에 실패했습니다</string>
 </resources>


### PR DESCRIPTION
## Summary
- implement `StampFragment` with CameraX capture and grid stamps
- persist stamp state with `StampViewModel`
- show back button in `StampActivity`
- enable ViewBinding and add CameraX dependencies
- add drawable resources and adapter

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6856670a721483228852699ce77cc655