### PR TITLE
Implement Firebase email auth

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.google.services)
 }
 
 import java.util.Properties

--- a/app/src/main/java/com/pnu/pnuguide/MainActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/MainActivity.kt
@@ -13,6 +13,8 @@ import com.pnu.pnuguide.ui.map.MapActivity
 import androidx.core.content.ContextCompat
 import com.pnu.pnuguide.ui.profile.ProfileFragment
 import com.pnu.pnuguide.ui.chat.ChatFragment
+import com.pnu.pnuguide.ui.LoginActivity
+import com.pnu.pnuguide.data.AuthRepository
 
 class MainActivity : AppCompatActivity() {
 
@@ -25,11 +27,18 @@ class MainActivity : AppCompatActivity() {
         toolbar = findViewById(R.id.toolbar)
         setSupportActionBar(toolbar)
         toolbar.setOnMenuItemClickListener { item ->
-            if (item.itemId == R.id.action_settings) {
-                startActivity(Intent(this, SettingsActivity::class.java))
-                true
-            } else {
-                false
+            when (item.itemId) {
+                R.id.action_settings -> {
+                    startActivity(Intent(this, SettingsActivity::class.java))
+                    true
+                }
+                R.id.action_logout -> {
+                    AuthRepository.signOut()
+                    startActivity(Intent(this, LoginActivity::class.java))
+                    finish()
+                    true
+                }
+                else -> false
             }
         }
 

--- a/app/src/main/java/com/pnu/pnuguide/data/AuthRepository.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/AuthRepository.kt
@@ -15,6 +15,23 @@ object AuthRepository {
         val result = auth.signInAnonymously().await()
         uid = result.user?.uid
     }
+
+    suspend fun signUp(email: String, password: String) {
+        val result = auth.createUserWithEmailAndPassword(email, password).await()
+        uid = result.user?.uid
+    }
+
+    suspend fun login(email: String, password: String) {
+        val result = auth.signInWithEmailAndPassword(email, password).await()
+        uid = result.user?.uid
+    }
+
+    fun signOut() {
+        auth.signOut()
+        uid = null
+    }
+
+    fun currentUser() = auth.currentUser
 }
 
 private suspend fun <T> Task<T>.await(): T = suspendCancellableCoroutine { cont ->

--- a/app/src/main/java/com/pnu/pnuguide/ui/LoginActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/LoginActivity.kt
@@ -2,24 +2,54 @@ package com.pnu.pnuguide.ui
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Patterns
+import android.widget.Toast
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import com.google.android.material.button.MaterialButton
+import androidx.lifecycle.lifecycleScope
 import com.pnu.pnuguide.MainActivity
-import com.pnu.pnuguide.R
+import com.pnu.pnuguide.databinding.ActivityLoginBinding
+import com.pnu.pnuguide.ui.auth.AuthViewModel
+import com.pnu.pnuguide.ui.auth.AuthViewModel.AuthState
 import com.pnu.pnuguide.ui.signup.SignUpActivity
+import kotlinx.coroutines.flow.collect
 
 class LoginActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityLoginBinding
+    private val viewModel: AuthViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_login)
+        binding = ActivityLoginBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        findViewById<MaterialButton>(R.id.button_login).setOnClickListener {
-            startActivity(Intent(this, MainActivity::class.java))
-            finish()
+        binding.buttonLogin.setOnClickListener {
+            val email = binding.editEmail.text.toString().trim()
+            val password = binding.editPassword.text.toString()
+            if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+                Toast.makeText(this, "Invalid email", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            viewModel.login(email, password)
         }
 
-        findViewById<MaterialButton>(R.id.button_signup).setOnClickListener {
+        binding.buttonSignup.setOnClickListener {
             startActivity(Intent(this, SignUpActivity::class.java))
+        }
+
+        lifecycleScope.launchWhenStarted {
+            viewModel.state.collect { state ->
+                when (state) {
+                    is AuthState.Success -> {
+                        startActivity(Intent(this@LoginActivity, MainActivity::class.java))
+                        finish()
+                    }
+                    is AuthState.Error -> {
+                        Toast.makeText(this@LoginActivity, state.message, Toast.LENGTH_SHORT).show()
+                    }
+                    else -> {}
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/OnboardingActivity.kt
@@ -7,12 +7,16 @@ import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
 import com.pnu.pnuguide.R
 import com.google.android.material.button.MaterialButton
+import com.pnu.pnuguide.MainActivity
+import com.pnu.pnuguide.data.AuthRepository
+import com.pnu.pnuguide.ui.LoginActivity
 
 class OnboardingActivity : AppCompatActivity() {
     private val handler = Handler(Looper.getMainLooper())
 
     private val navigateRunnable = Runnable {
-        startActivity(Intent(this, LoginActivity::class.java))
+        val dest = if (AuthRepository.currentUser() != null) MainActivity::class.java else LoginActivity::class.java
+        startActivity(Intent(this, dest))
         finish()
     }
 
@@ -28,7 +32,11 @@ class OnboardingActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        handler.postDelayed(navigateRunnable, 2000)
+        if (AuthRepository.currentUser() != null) {
+            navigateRunnable.run()
+        } else {
+            handler.postDelayed(navigateRunnable, 2000)
+        }
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/pnu/pnuguide/ui/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/auth/AuthViewModel.kt
@@ -1,0 +1,48 @@
+package com.pnu.pnuguide.ui.auth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pnu.pnuguide.data.AuthRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class AuthViewModel : ViewModel() {
+    sealed class AuthState {
+        object Idle : AuthState()
+        object Loading : AuthState()
+        object Success : AuthState()
+        data class Error(val message: String) : AuthState()
+    }
+
+    private val _state = MutableStateFlow<AuthState>(AuthState.Idle)
+    val state: StateFlow<AuthState> = _state
+
+    fun login(email: String, password: String) {
+        viewModelScope.launch {
+            _state.value = AuthState.Loading
+            try {
+                AuthRepository.login(email, password)
+                _state.value = AuthState.Success
+            } catch (e: Exception) {
+                _state.value = AuthState.Error(e.message ?: "Error")
+            }
+        }
+    }
+
+    fun signUp(email: String, password: String) {
+        viewModelScope.launch {
+            _state.value = AuthState.Loading
+            try {
+                AuthRepository.signUp(email, password)
+                _state.value = AuthState.Success
+            } catch (e: Exception) {
+                _state.value = AuthState.Error(e.message ?: "Error")
+            }
+        }
+    }
+
+    fun signOut() {
+        AuthRepository.signOut()
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/signup/SignUpActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/signup/SignUpActivity.kt
@@ -2,19 +2,60 @@ package com.pnu.pnuguide.ui.signup
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Patterns
+import android.widget.Toast
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import com.google.android.material.button.MaterialButton
-import com.pnu.pnuguide.R
+import androidx.lifecycle.lifecycleScope
 import com.pnu.pnuguide.ui.LoginActivity
+import com.pnu.pnuguide.MainActivity
+import com.pnu.pnuguide.databinding.ActivitySignUpBinding
+import com.pnu.pnuguide.ui.auth.AuthViewModel
+import com.pnu.pnuguide.ui.auth.AuthViewModel.AuthState
+import kotlinx.coroutines.flow.collect
 
 class SignUpActivity : AppCompatActivity() {
+    private lateinit var binding: ActivitySignUpBinding
+    private val viewModel: AuthViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_sign_up)
+        binding = ActivitySignUpBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        findViewById<MaterialButton>(R.id.button_sign_up).setOnClickListener {
-            startActivity(Intent(this, LoginActivity::class.java))
-            finish()
+        binding.buttonSignUp.setOnClickListener {
+            val email = binding.editEmail.text.toString().trim()
+            val password = binding.editPassword.text.toString()
+            val confirm = binding.editConfirmPassword.text.toString()
+
+            if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+                Toast.makeText(this, "Invalid email", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            if (password.length < 6) {
+                Toast.makeText(this, "Password must be at least 6 characters", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            if (password != confirm) {
+                Toast.makeText(this, "Passwords do not match", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            viewModel.signUp(email, password)
+        }
+
+        lifecycleScope.launchWhenStarted {
+            viewModel.state.collect { state ->
+                when (state) {
+                    is AuthState.Success -> {
+                        startActivity(Intent(this@SignUpActivity, MainActivity::class.java))
+                        finish()
+                    }
+                    is AuthState.Error -> {
+                        Toast.makeText(this@SignUpActivity, state.message, Toast.LENGTH_SHORT).show()
+                    }
+                    else -> {}
+                }
+            }
         }
     }
 }

--- a/app/src/main/res/drawable/ic_logout.xml
+++ b/app/src/main/res/drawable/ic_logout.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#FF000000"
+        android:pathData="M17,7L15.59,8.41 18.17,11H8v2h10.17l-2.58,2.59L17,17l5-5-5-5zM4,5h8V3H4c-1.1,0-2,0.9-2,2v14c0,1.1,0.9,2,2,2h8v-2H4V5z"/>
+</vector>

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -37,16 +37,6 @@
                 android:orientation="vertical"
                 android:padding="24dp">
 
-                <EditText
-                    android:id="@+id/edit_name"
-                    android:layout_width="match_parent"
-                    android:layout_height="48dp"
-                    android:background="@color/divider"
-                    android:hint="@string/name"
-                    android:padding="12dp"
-                    android:textColor="@color/text_primary"
-                    android:textColorHint="@color/text_secondary"
-                    android:layout_marginBottom="12dp" />
 
                 <EditText
                     android:id="@+id/edit_email"
@@ -65,6 +55,18 @@
                     android:layout_height="48dp"
                     android:background="@color/divider"
                     android:hint="@string/password"
+                    android:padding="12dp"
+                    android:textColor="@color/text_primary"
+                    android:textColorHint="@color/text_secondary"
+                    android:inputType="textPassword"
+                    android:layout_marginBottom="12dp" />
+
+                <EditText
+                    android:id="@+id/edit_confirm_password"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:background="@color/divider"
+                    android:hint="@string/confirm_password"
                     android:padding="12dp"
                     android:textColor="@color/text_primary"
                     android:textColorHint="@color/text_secondary"

--- a/app/src/main/res/menu/menu_home_toolbar.xml
+++ b/app/src/main/res/menu/menu_home_toolbar.xml
@@ -6,4 +6,9 @@
         android:icon="@drawable/ic_settings"
         android:title="@string/settings"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/action_logout"
+        android:icon="@drawable/ic_logout"
+        android:title="@string/logout"
+        app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,8 +18,10 @@
     <string name="log_in_or_sign_up">Log in or sign up</string>
     <string name="email">Email</string>
     <string name="password">Password</string>
+    <string name="confirm_password">Confirm password</string>
     <string name="name">Name</string>
     <string name="settings">Settings</string>
+    <string name="logout">Log out</string>
     <string name="pnu_guide">PNU Guide</string>
     <string name="pnu_guide_update">PNU Guide Update</string>
     <string name="title_course">Course</string>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.google.services) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,4 +39,5 @@ coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-andro
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+google-services = { id = "com.google.gms.google-services", version = "4.4.1" }
 


### PR DESCRIPTION
## Summary
- enable Google Services plugin
- extend `AuthRepository` to support email/password auth
- create `AuthViewModel` with `StateFlow`
- wire Login/SignUp activities to Firebase using view binding
- check auth status in `OnboardingActivity`
- add logout option in toolbar
- update layouts and strings for sign-up flow

## Testing
- `./gradlew assembleDebug` *(fails: Unable to complete due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6856bf4b017c8322b7e2460c8ec9ad59