### PR TITLE
Implement actual ML inference for stamp recognition

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/data/MLImageHelper.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/MLImageHelper.kt
@@ -1,5 +1,6 @@
 package com.pnu.pnuguide.data
 
+import android.content.Context
 import android.graphics.Bitmap
 import org.tensorflow.lite.DataType
 import org.tensorflow.lite.support.image.TensorImage
@@ -7,8 +8,13 @@ import org.tensorflow.lite.support.tensorbuffer.TensorBuffer
 import org.tensorflow.lite.support.image.ImageProcessor
 import org.tensorflow.lite.support.image.ops.ResizeOp
 import org.tensorflow.lite.support.common.ops.NormalizeOp
+import org.tensorflow.lite.Interpreter
 
 object MLImageHelper {
+    private var model: Any? = null
+    private var labels: List<String>? = null
+    private var embeddings: Array<FloatArray>? = null
+
     fun bitmapToTensorImage(bitmap: Bitmap): TensorImage {
         val processor = ImageProcessor.Builder()
             .add(ResizeOp(224, 224, ResizeOp.ResizeMethod.BILINEAR))
@@ -22,9 +28,122 @@ object MLImageHelper {
     fun bitmapToTensorBuffer(bitmap: Bitmap): TensorBuffer {
         return bitmapToTensorImage(bitmap).tensorBuffer
     }
-    suspend fun matchSpot(bitmap: Bitmap): String? {
-        // TODO: replace this placeholder logic with TensorFlow Lite model inference
-        return if (bitmap.width > 0 && bitmap.height > 0) "dummy_spot" else null
+
+    private fun ensureLoaded(context: Context) {
+        if (model == null) {
+            model = ModelLoader.loadModel(context)
+        }
+        if (labels == null) {
+            labels = ModelLoader.loadLabels(context)
+        }
+        if (embeddings == null) {
+            embeddings = loadEmbeddings(context)
+        }
+    }
+
+    private fun loadEmbeddings(context: Context): Array<FloatArray> {
+        context.assets.open("embeddings.npy").use { input ->
+            val magic = ByteArray(6)
+            input.read(magic)
+            input.skip(2) // version
+            val headerLenBytes = ByteArray(2)
+            input.read(headerLenBytes)
+            val headerLen = java.nio.ByteBuffer.wrap(headerLenBytes)
+                .order(java.nio.ByteOrder.LITTLE_ENDIAN).short.toInt()
+            val headerBytes = ByteArray(headerLen)
+            input.read(headerBytes)
+            val header = String(headerBytes)
+            val shapeMatch = Regex("\\((\\d+),\\s*(\\d+)\\)").find(header)
+            val rows = shapeMatch?.groupValues?.getOrNull(1)?.toInt() ?: 0
+            val cols = shapeMatch?.groupValues?.getOrNull(2)?.toInt() ?: 0
+            val floats = ByteArray(rows * cols * 4)
+            input.read(floats)
+            val bb = java.nio.ByteBuffer.wrap(floats)
+                .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+            return Array(rows) { r -> FloatArray(cols) { bb.float } }
+        }
+    }
+
+    private fun cosineSimilarity(a: FloatArray, b: FloatArray): Float {
+        var dot = 0f
+        var normA = 0f
+        var normB = 0f
+        for (i in a.indices) {
+            dot += a[i] * b[i]
+            normA += a[i] * a[i]
+            normB += b[i] * b[i]
+        }
+        return if (normA == 0f || normB == 0f) 0f
+        else (dot / kotlin.math.sqrt(normA * normB))
+    }
+
+    private fun runTflite(interpreter: Interpreter, bitmap: Bitmap): FloatArray {
+        val input = bitmapToTensorBuffer(bitmap)
+        val output = Array(1) { FloatArray(1280) }
+        interpreter.run(input.buffer, output)
+        return output[0]
+    }
+
+    private fun runPyTorch(module: Any, bitmap: Bitmap): FloatArray {
+        return try {
+            val tensorClass = Class.forName("org.pytorch.Tensor")
+            val fromBlob = tensorClass.getMethod(
+                "fromBlob",
+                FloatArray::class.java,
+                LongArray::class.java
+            )
+            val chw = bitmapToCHWArray(bitmap)
+            val tensor = fromBlob.invoke(null, chw, longArrayOf(1, 3, 224, 224))
+
+            val ivalueClass = Class.forName("org.pytorch.IValue")
+            val fromTensor = ivalueClass.getMethod("from", tensorClass)
+            val inputVal = fromTensor.invoke(null, tensor)
+
+            val moduleClass = Class.forName("org.pytorch.Module")
+            val forward = moduleClass.getMethod("forward", ivalueClass)
+            val outValue = forward.invoke(module, inputVal)
+
+            val toTensor = ivalueClass.getMethod("toTensor")
+            val outTensor = toTensor.invoke(outValue)
+
+            val dataMethod = tensorClass.getMethod("getDataAsFloatArray")
+            dataMethod.invoke(outTensor) as FloatArray
+        } catch (e: Exception) {
+            throw IllegalStateException("PyTorch inference failed", e)
+        }
+    }
+
+    private fun bitmapToCHWArray(bitmap: Bitmap): FloatArray {
+        val scaled = Bitmap.createScaledBitmap(bitmap, 224, 224, true)
+        val result = FloatArray(3 * 224 * 224)
+        var rIdx = 0
+        var gIdx = 224 * 224
+        var bIdx = 2 * 224 * 224
+        for (y in 0 until 224) {
+            for (x in 0 until 224) {
+                val pixel = scaled.getPixel(x, y)
+                result[rIdx++] = ((pixel shr 16) and 0xFF) / 255f
+                result[gIdx++] = ((pixel shr 8) and 0xFF) / 255f
+                result[bIdx++] = (pixel and 0xFF) / 255f
+            }
+        }
+        return result
+    }
+
+    suspend fun matchSpot(context: Context, bitmap: Bitmap): String? {
+        ensureLoaded(context)
+        val modelLocal = model ?: return null
+        val feature = when (modelLocal) {
+            is Interpreter -> runTflite(modelLocal, bitmap)
+            else -> runPyTorch(modelLocal, bitmap)
+        }
+
+        val embs = embeddings ?: return null
+        val bestIdx = embs.indices.maxByOrNull { idx ->
+            cosineSimilarity(feature, embs[idx])
+        } ?: return null
+        val lbls = labels ?: return null
+        return lbls.getOrNull(bestIdx)
     }
 }
 

--- a/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampViewModel.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampViewModel.kt
@@ -42,7 +42,7 @@ class StampViewModel(private val app: Application) : AndroidViewModel(app) {
 
     fun processBitmap(bitmap: Bitmap, targetId: String) {
         viewModelScope.launch(Dispatchers.IO) {
-            val match = MLImageHelper.matchSpot(bitmap)
+            val match = MLImageHelper.matchSpot(app, bitmap)
             if (match == targetId) {
                 markStamp(targetId)
             } else {


### PR DESCRIPTION
## Summary
- load labels, model, and embeddings when matching a stamp
- add TensorFlow Lite/PyTorch inference to `MLImageHelper.matchSpot`
- update `StampViewModel` to provide context for matching

## Testing
- `./gradlew test` *(fails: Gradle needed network access to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685809a3e5f48322a8329c8938c24267