### PR TITLE
Fix Stamp bottom navigation layout

### DIFF
--- a/app/src/main/res/layout/fragment_stamp.xml
+++ b/app/src/main/res/layout/fragment_stamp.xml
@@ -19,30 +19,14 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:titleCentered="true" />
 
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/text_stamp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Stamp Fragment" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/btn_download_pdf"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/download_map" />
-        </LinearLayout>
-    </FrameLayout>
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_download_pdf"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/download_map"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_stamp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_nav"
@@ -54,7 +38,10 @@
         app:itemIconSize="@dimen/bottom_nav_icon_size"
         app:labelVisibilityMode="unlabeled"
         app:itemHorizontalTranslationEnabled="false"
-        app:menu="@menu/menu_bottom_nav" />
+        app:menu="@menu/menu_bottom_nav"
+        app:layout_constraintBottom_toTopOf="@id/bottom_labels"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <LinearLayout
         android:id="@+id/bottom_labels"
@@ -62,7 +49,10 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="-4dp"
         android:orientation="horizontal"
-        android:background="@color/background_light">
+        android:background="@color/background_light"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <TextView
             android:layout_width="0dp"
@@ -106,10 +96,10 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         tools:listitem="@layout/item_stamp_row"
-        app:layout_constraintTop_toBottomOf="@id/toolbar_stamp"
+        app:layout_constraintTop_toBottomOf="@id/btn_download_pdf"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        app:layout_constraintBottom_toTopOf="@id/bottom_nav"/>
 
     <androidx.camera.view.PreviewView
         android:id="@+id/preview_view"


### PR DESCRIPTION
## Summary
- fix `fragment_stamp.xml` so the bottom navigation stays anchored
- adjust stamp screen constraints so stamp list is visible

## Testing
- `./gradlew test --continue` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685815e22dfc8322b3896877789dc8b2