### PR TITLE
Fix StampActivity layout

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
@@ -24,7 +24,9 @@ import androidx.core.content.ContextCompat
 class StampActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.fragment_stamp)
+        // Use the dedicated activity layout which hosts the fragment
+        // so that the fragment logic is executed properly.
+        setContentView(R.layout.activity_stamp)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_stamp)
         toolbar.setupHeader1(this, R.string.title_stamp)


### PR DESCRIPTION
## Summary
- use `activity_stamp.xml` so the stamp fragment loads correctly

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581c4c28508322b91372a4805a9cd0