### PR TITLE
Add StampActivity with camera capture button

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.pnuguide">
+
+    <application
+        android:allowBackup="true"
+        android:label="PNUGuide"
+        android:supportsRtl="true">
+        <activity android:name=".StampActivity" />
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/pnuguide/StampActivity.kt
+++ b/app/src/main/java/com/example/pnuguide/StampActivity.kt
@@ -1,0 +1,22 @@
+package com.example.pnuguide
+
+import android.content.Intent
+import android.os.Bundle
+import android.provider.MediaStore
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+
+class StampActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_stamp)
+
+        val captureButton: Button = findViewById(R.id.button_capture)
+        captureButton.setOnClickListener {
+            val cameraIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+            if (cameraIntent.resolveActivity(packageManager) != null) {
+                startActivity(cameraIntent)
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_stamp.xml
+++ b/app/src/main/res/layout/activity_stamp.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <Button
+        android:id="@+id/button_capture"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="사진으로 인증하기" />
+
+</LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    compileSdkVersion 33
+
+    defaultConfig {
+        applicationId "com.example.pnuguide"
+        minSdkVersion 21
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+}
+
+dependencies {
+    implementation "androidx.appcompat:appcompat:1.4.1"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+include ':app'
+rootProject.name = 'PNUGuide'


### PR DESCRIPTION
## Summary
- create minimal Android config
- add StampActivity that opens the camera
- simplify `activity_stamp.xml` to a single photo button

## Testing
- `gradle test` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582aa7074c8322be6cf926f97ef89d