### PR TITLE
Revamp stamp UI

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampFragment.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampFragment.kt
@@ -18,7 +18,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory
-import androidx.recyclerview.widget.LinearLayoutManager
 import java.io.File
 
 import com.pnu.pnuguide.databinding.FragmentStampBinding
@@ -40,7 +39,6 @@ class StampFragment : Fragment() {
 
     private var imageCapture: ImageCapture? = null
     private var cameraProvider: ProcessCameraProvider? = null
-    private var currentStampId: String? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -53,20 +51,13 @@ class StampFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.recyclerStamps.layoutManager = LinearLayoutManager(requireContext())
-        val adapter = StampAdapter { stamp ->
-            currentStampId = stamp.id
+        binding.buttonStartCamera.setOnClickListener {
             if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA)
                 == PackageManager.PERMISSION_GRANTED) {
                 startCamera()
             } else {
                 requestPermission.launch(Manifest.permission.CAMERA)
             }
-        }
-        binding.recyclerStamps.adapter = adapter
-
-        viewModel.stamps.observe(viewLifecycleOwner) {
-            adapter.submitList(it)
         }
 
         viewModel.error.observe(viewLifecycleOwner) { failed ->
@@ -110,7 +101,7 @@ class StampFragment : Fragment() {
                 binding.buttonCapture.visibility = View.GONE
                 cameraProvider?.unbindAll()
                 cameraProvider = null
-                currentStampId?.let { viewModel.processImage(file, it) }
+                viewModel.processImage(file)
             }
 
             override fun onError(exception: ImageCaptureException) {

--- a/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampViewModel.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampViewModel.kt
@@ -33,18 +33,18 @@ class StampViewModel(private val app: Application) : AndroidViewModel(app) {
         prefs.edit().putBoolean(id, true).apply()
     }
 
-    fun processImage(file: File, targetId: String) {
+    fun processImage(file: File) {
         viewModelScope.launch(Dispatchers.IO) {
             val bitmap = BitmapFactory.decodeFile(file.absolutePath)
-            processBitmap(bitmap, targetId)
+            processBitmap(bitmap)
         }
     }
 
-    fun processBitmap(bitmap: Bitmap, targetId: String) {
+    fun processBitmap(bitmap: Bitmap) {
         viewModelScope.launch(Dispatchers.IO) {
             val match = MLImageHelper.matchSpot(app, bitmap)
-            if (match == targetId) {
-                markStamp(targetId)
+            if (match != null) {
+                markStamp(match)
             } else {
                 _error.postValue(true)
             }

--- a/app/src/main/res/layout/fragment_stamp.xml
+++ b/app/src/main/res/layout/fragment_stamp.xml
@@ -91,23 +91,23 @@
             android:textSize="12sp" />
     </LinearLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recycler_stamps"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        tools:listitem="@layout/item_stamp_row"
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_start_camera"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/stamp_capture"
         app:layout_constraintTop_toBottomOf="@id/btn_download_pdf"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/bottom_nav"/>
+        app:layout_constraintBottom_toTopOf="@id/bottom_nav" />
 
     <androidx.camera.view.PreviewView
         android:id="@+id/preview_view"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:visibility="gone"
-        app:layout_constraintTop_toTopOf="@id/recycler_stamps"
-        app:layout_constraintBottom_toBottomOf="@id/recycler_stamps"
+        app:layout_constraintTop_toTopOf="@id/button_start_camera"
+        app:layout_constraintBottom_toBottomOf="@id/button_start_camera"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,6 @@
     <string name="download_map">Download Campus Map</string>
     <string name="tour_apply">Campus Tour Application</string>
     <string name="open_youtube">Official YouTube</string>
-    <string name="stamp_capture">인증하기</string>
+    <string name="stamp_capture">사진으로 인증하기</string>
     <string name="stamp_failed">인증에 실패했습니다</string>
 </resources>


### PR DESCRIPTION
## Summary
- replace 24 stamp list with single `사진으로 인증하기` button
- update string resource for new label
- adjust camera capture logic to work without stamp selection

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582c646f2c8322902207fbee8f3875