### PR TITLE
Display ML label after photo capture

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampFragment.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampFragment.kt
@@ -64,6 +64,13 @@ class StampFragment : Fragment() {
             }
         }
 
+        viewModel.label.observe(viewLifecycleOwner) { label ->
+            label?.let {
+                Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+                viewModel.clearLabel()
+            }
+        }
+
 
         // Return to the previous screen (typically Home) when back icon is pressed
         binding.toolbarStamp.setNavigationOnClickListener {

--- a/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampViewModel.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampViewModel.kt
@@ -21,6 +21,9 @@ class StampViewModel(private val app: Application) : AndroidViewModel(app) {
     private val _stamps = MutableLiveData<List<Stamp>>(loadStamps())
     val stamps: LiveData<List<Stamp>> = _stamps
 
+    private val _label = MutableLiveData<String?>(null)
+    val label: LiveData<String?> = _label
+
     private fun loadStamps(): List<Stamp> {
         val fromCourse = CourseData.loadStamps()
         return fromCourse.mapIndexed { index, stamp ->
@@ -44,6 +47,7 @@ class StampViewModel(private val app: Application) : AndroidViewModel(app) {
         viewModelScope.launch(Dispatchers.IO) {
             val match = MLImageHelper.matchSpot(app, bitmap)
             if (match != null) {
+                _label.postValue(match)
                 markStamp(match)
             } else {
                 _error.postValue(true)
@@ -65,4 +69,6 @@ class StampViewModel(private val app: Application) : AndroidViewModel(app) {
     val error: LiveData<Boolean> = _error
 
     fun clearError() { _error.value = false }
+
+    fun clearLabel() { _label.value = null }
 }


### PR DESCRIPTION
## Summary
- expose label in `StampViewModel`
- show recognized label with a toast in `StampFragment`

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858327e9844832287f0e736a6a34476