### PR TITLE
Fix ML label to quiz mapping

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/data/LabelMappings.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/LabelMappings.kt
@@ -1,0 +1,31 @@
+package com.pnu.pnuguide.data
+
+object LabelMappings {
+    val labelToTitle = mapOf(
+        "m" to "약학관",
+        "tensix" to "10.16기념관",
+        "jinli" to "진리의 뜰",
+        "bres" to "샛벌회관 식당",
+        "minju" to "민주 언덕",
+        "sres" to "학생회관 식당",
+        "inmun" to "인문관",
+        "miri" to "미리내 골",
+        "vs" to "기계관 V-SPACE",
+        "ten" to "시월 광장",
+        "nuck" to "넉넉한 터",
+        "busy" to "경영관",
+        "head" to "대학본부",
+        "gres" to "금정회관 식당",
+        "cafe" to "cafe 운죽정",
+        "yea" to "예원정",
+        "sae_do" to "새벽벌 도서관",
+        "music" to "음악관",
+        "museum" to "박물관",
+        "beopjeong" to "법학관 모의 법정",
+        "a" to "건설관",
+        "p" to "경암체육관",
+        "jijil" to "지질박물관",
+        "ang" to "중앙도서관",
+        "piece" to "조각공원"
+    )
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
@@ -322,7 +322,8 @@ class QuizActivity : AppCompatActivity() {
         const val EXTRA_LAYOUT_RES = "extra_layout_res"
 
         fun start(context: Context, title: String) {
-            val layoutRes = when (title) {
+            val resolved = com.pnu.pnuguide.data.LabelMappings.labelToTitle[title] ?: title
+            val layoutRes = when (resolved) {
                 "대학본부" -> R.layout.activity_quiz_1
                 "조각공원" -> R.layout.activity_quiz_2
                 "새벽벌도서관" -> R.layout.activity_quiz_3
@@ -356,7 +357,7 @@ class QuizActivity : AppCompatActivity() {
                 else -> R.layout.activity_quiz
             }
             val intent = Intent(context, QuizActivity::class.java)
-            intent.putExtra(EXTRA_TITLE, title)
+            intent.putExtra(EXTRA_TITLE, resolved)
             intent.putExtra(EXTRA_LAYOUT_RES, layoutRes)
             context.startActivity(intent)
         }


### PR DESCRIPTION
## Summary
- map ML label codes to Korean quiz titles
- resolve quiz title from label codes before launching activity

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685836f9fc0483229562a46772910eba