### PR TITLE
Add mapping for ML label codes

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/data/LabelMappings.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/LabelMappings.kt
@@ -1,0 +1,31 @@
+package com.pnu.pnuguide.data
+
+object LabelMappings {
+    val labelToTitle = mapOf(
+        "m" to "약학관",
+        "tensix" to "10.16 기념관",
+        "jinli" to "진리의 뜰",
+        "bres" to "샛벌회관 식당",
+        "minju" to "민주 언덕",
+        "sres" to "학생회관 식당",
+        "inmun" to "인문관",
+        "miri" to "미리내 골",
+        "vs" to "기계관 V-SPACE",
+        "ten" to "시월 광장",
+        "nuck" to "넉넉한터",
+        "busy" to "경영관",
+        "head" to "대학본부",
+        "gres" to "금정회관 식당",
+        "cafe" to "cafe 운죽정",
+        "yea" to "예원정",
+        "sae_do" to "새벽벌 도서관",
+        "music" to "음악관",
+        "museum" to "박물관",
+        "beopjeong" to "법학관 모의 법정",
+        "a" to "건설관",
+        "p" to "경암 체육관",
+        "jijil" to "지질박물관",
+        "ang" to "중앙도서관",
+        "piece" to "조각공원"
+    )
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
@@ -321,7 +321,8 @@ class QuizActivity : AppCompatActivity() {
         const val EXTRA_TITLE = "extra_title"
         const val EXTRA_LAYOUT_RES = "extra_layout_res"
 
-        fun start(context: Context, title: String) {
+        fun start(context: Context, label: String) {
+            val title = com.pnu.pnuguide.data.LabelMappings.labelToTitle[label] ?: label
             val layoutRes = when (title) {
                 "대학본부" -> R.layout.activity_quiz_1
                 "조각공원" -> R.layout.activity_quiz_2

--- a/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampFragment.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampFragment.kt
@@ -65,8 +65,8 @@ class StampFragment : Fragment() {
             }
         }
 
-        viewModel.label.observe(viewLifecycleOwner) { label ->
-            label?.let {
+        viewModel.label.observe(viewLifecycleOwner) { code ->
+            code?.let {
                 QuizActivity.start(requireContext(), it)
                 viewModel.clearLabel()
             }


### PR DESCRIPTION
## Summary
- map ML label codes to Korean titles
- use the mapping when starting a quiz
- tweak `StampFragment` to pass the label code

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685839b91a0c8322a88e0d8ec29664e3