### PR TITLE
Add ML label mapping

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
@@ -321,9 +321,9 @@ class QuizActivity : AppCompatActivity() {
         const val EXTRA_TITLE = "extra_title"
         const val EXTRA_LAYOUT_RES = "extra_layout_res"
 
-        fun start(context: Context, title: String) {
-            val resolved = com.pnu.pnuguide.data.LabelMappings.labelToTitle[title] ?: title
-            val layoutRes = when (resolved) {
+        fun start(context: Context, label: String) {
+            val title = com.pnu.pnuguide.data.LabelMappings.labelToTitle[label] ?: label
+            val layoutRes = when (title) {
                 "대학본부" -> R.layout.activity_quiz_1
                 "조각공원" -> R.layout.activity_quiz_2
                 "새벽벌도서관" -> R.layout.activity_quiz_3
@@ -357,7 +357,7 @@ class QuizActivity : AppCompatActivity() {
                 else -> R.layout.activity_quiz
             }
             val intent = Intent(context, QuizActivity::class.java)
-            intent.putExtra(EXTRA_TITLE, resolved)
+            intent.putExtra(EXTRA_TITLE, title)
             intent.putExtra(EXTRA_LAYOUT_RES, layoutRes)
             context.startActivity(intent)
         }

--- a/app/src/test/java/com/pnu/pnuguide/LabelMappingsTest.kt
+++ b/app/src/test/java/com/pnu/pnuguide/LabelMappingsTest.kt
@@ -1,0 +1,19 @@
+package com.pnu.pnuguide
+
+import com.google.gson.Gson
+import com.pnu.pnuguide.data.LabelMappings
+import org.junit.Test
+import org.junit.Assert.assertTrue
+import java.io.File
+
+class LabelMappingsTest {
+    @Test
+    fun allLabelsHaveMappings() {
+        val labelsFile = File("src/main/assets/labels.json")
+        val json = labelsFile.readText()
+        val labels: Array<String> = Gson().fromJson(json, Array<String>::class.java)
+        for (code in labels) {
+            assertTrue("Mapping missing for $code", LabelMappings.labelToTitle.containsKey(code))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- connect ML label codes to Korean spot titles
- lookup labels when starting quiz
- test mapping coverage

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685842410dcc8322b1cc9ab9f85390c1