### PR TITLE
Fix PyTorch model loading fallback

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/data/ModelLoader.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/ModelLoader.kt
@@ -15,11 +15,21 @@ object ModelLoader {
                 val buffer = FileUtil.loadMappedFile(context, "mobile_feature.tflite")
                 Interpreter(buffer)
             }
+            assetExists(assets, "mobile_feature.ptl") -> {
+                val buffer = FileUtil.loadMappedFile(context, "mobile_feature.ptl")
+                try {
+                    val loaderClass = Class.forName("org.pytorch.LiteModuleLoader")
+                    val loadMethod = loaderClass.getMethod("load", java.nio.ByteBuffer::class.java)
+                    loadMethod.invoke(null, buffer)
+                } catch (e: Exception) {
+                    throw IllegalStateException("PyTorch Mobile library missing", e)
+                }
+            }
             assetExists(assets, "mobile_feature.pt") -> {
                 val buffer = FileUtil.loadMappedFile(context, "mobile_feature.pt")
                 try {
-                    val moduleClass = Class.forName("org.pytorch.Module")
-                    val loadMethod = moduleClass.getMethod("load", java.nio.ByteBuffer::class.java)
+                    val loaderClass = Class.forName("org.pytorch.LiteModuleLoader")
+                    val loadMethod = loaderClass.getMethod("load", java.nio.ByteBuffer::class.java)
                     loadMethod.invoke(null, buffer)
                 } catch (e: Exception) {
                     throw IllegalStateException("PyTorch Mobile library missing", e)


### PR DESCRIPTION
## Summary
- fix fallback model loading logic to properly load `.pt`/`.ptl` models via `LiteModuleLoader`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68585897d1648322a280b7030fe4a993