### PR TITLE
Enable TFLite-based stamp classification

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/data/MLImageHelper.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/MLImageHelper.kt
@@ -131,19 +131,9 @@ object MLImageHelper {
     }
 
     suspend fun matchSpot(context: Context, bitmap: Bitmap): String? {
-        ensureLoaded(context)
-        val modelLocal = model ?: return null
-        val feature = when (modelLocal) {
-            is Interpreter -> runTflite(modelLocal, bitmap)
-            else -> runPyTorch(modelLocal, bitmap)
-        }
-
-        val embs = embeddings ?: return null
-        val bestIdx = embs.indices.maxByOrNull { idx ->
-            cosineSimilarity(feature, embs[idx])
-        } ?: return null
-        val lbls = labels ?: return null
-        return lbls.getOrNull(bestIdx)
+        // For compatibility with existing call sites, forward to classifyImage
+        // which uses the TensorFlow Lite model to directly predict the label.
+        return classifyImage(context, bitmap)
     }
 
     /**

--- a/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampViewModel.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampViewModel.kt
@@ -45,7 +45,9 @@ class StampViewModel(private val app: Application) : AndroidViewModel(app) {
 
     fun processBitmap(bitmap: Bitmap) {
         viewModelScope.launch(Dispatchers.IO) {
-            val match = MLImageHelper.matchSpot(app, bitmap)
+            // Use MLImageHelper to classify the captured photo with the
+            // TensorFlow Lite model bundled in assets.
+            val match = MLImageHelper.classifyImage(app, bitmap)
             if (match != null) {
                 _label.postValue(match)
                 markStamp(match)


### PR DESCRIPTION
## Summary
- use `classifyImage` inside `MLImageHelper.matchSpot`
- stamp screen now classifies captured images via the bundled TFLite model

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68585f160bd88322b6d46cc5d95ad64c