### PR TITLE
Add toast for detected stamp label

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampFragment.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.TakePicturePreview
 import androidx.core.content.ContextCompat
@@ -15,6 +16,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory
 import com.pnu.pnuguide.ui.quiz.QuizActivity
+import com.pnu.pnuguide.R
 
 import com.pnu.pnuguide.databinding.FragmentStampBinding
 
@@ -67,6 +69,11 @@ class StampFragment : Fragment() {
 
         viewModel.label.observe(viewLifecycleOwner) { label ->
             label?.let {
+                Log.d("StampFragment", "Recognized label: $it")
+                Toast.makeText(requireContext(),
+                    getString(R.string.stamp_label_detected, it),
+                    Toast.LENGTH_SHORT
+                ).show()
                 QuizActivity.start(requireContext(), it)
                 viewModel.clearLabel()
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,4 +40,5 @@
     <string name="open_youtube">Official YouTube</string>
     <string name="stamp_capture">사진으로 인증하기</string>
     <string name="stamp_failed">인증에 실패했습니다</string>
+    <string name="stamp_label_detected">인식된 스팟: %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- show recognized label via log and toast before starting quiz
- add string resource for this message

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*
- `./gradlew lint --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685860bdafbc8322a2ab9b74d87a134d