### PR TITLE
Fix vector drawable circle attributes

### DIFF
--- a/app/src/main/res/drawable/ic_camera_blue.xml
+++ b/app/src/main/res/drawable/ic_camera_blue.xml
@@ -3,11 +3,11 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-    <circle
+    <!-- Using a path instead of the circle element for wider
+         compatibility with older build tools -->
+    <path
         android:fillColor="@color/primary"
-        android:cx="12"
-        android:cy="12"
-        android:r="3.2" />
+        android:pathData="M12 8.8a3.2 3.2 0 1 0 0 6.4a3.2 3.2 0 1 0 0 -6.4z" />
     <path
         android:fillColor="@color/primary"
         android:pathData="M9 2L7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2H9zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5z" />


### PR DESCRIPTION
## Summary
- replace unsupported `<circle>` element in `ic_camera_blue.xml` with a `path`

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685877d97b30832283d7133d401d60a7