### PR TITLE
Configure release signing via keystore properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 .cxx
 local.properties
 .kotlin/
+
+keystore.properties
+*.jks
+*.keystore

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,6 +34,23 @@ android {
         ?: System.getenv("MAPS_API_KEY")
         ?: "API_KEY_MISSING"
 
+    val keystoreProps = Properties()
+    val keystorePropsFile = rootProject.file("keystore.properties")
+    if (keystorePropsFile.exists()) {
+        keystoreProps.load(FileInputStream(keystorePropsFile))
+    }
+
+    signingConfigs {
+        create("release") {
+            if (keystorePropsFile.exists()) {
+                storeFile = file(keystoreProps["storeFile"] as String)
+                storePassword = keystoreProps["storePassword"] as String
+                keyAlias = keystoreProps["keyAlias"] as String
+                keyPassword = keystoreProps["keyPassword"] as String
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -44,6 +61,7 @@ android {
             buildConfigField("String", "OPENAI_API_KEY", "\"$openAiKey\"")
             buildConfigField("String", "MAPS_API_KEY", "\"$mapsApiKey\"")
             manifestPlaceholders["MAPS_API_KEY"] = mapsApiKey
+            signingConfig = signingConfigs.getByName("release")
         }
         debug {
             buildConfigField("String", "OPENAI_API_KEY", "\"$openAiKey\"")


### PR DESCRIPTION
## Summary
- ignore keystore and `keystore.properties`
- load signing credentials from `keystore.properties`
- apply release signing configuration

## Testing
- `./gradlew -b build.gradle.kts test` *(fails: Plugin [id: 'com.android.application', version: '8.9.0', apply: false] not found)*

------
https://chatgpt.com/codex/tasks/task_e_688de69aba248322a60e4fc85305ebae